### PR TITLE
Add choc v1 & v2 led cutout marks support

### DIFF
--- a/switch_choc_v1_v2.js
+++ b/switch_choc_v1_v2.js
@@ -220,20 +220,20 @@ module.exports = {
     (fp_line (start 7 -7) (end 7 -6) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
     `
 
-    const choc_v1_led_cutout_marks = `
-    ${''/* choc v1 led cutout marks */}
-    (fp_line (start -2.65 6.325) (end 2.65 3.075) (layer "Dwgs.User") (width 0.15) (stroke (width 0.15) (type solid)))
-    `
-
-    const choc_v2_led_cutout_marks = `
-    ${''/* choc v2 led cutout marks */}
-    (fp_line (start -2.75 6.405) (end 2.75 3.455) (layer "Dwgs.User") (width 0.15) (stroke (width 0.15) (type solid)))
-    `
-
     const keycap_xo = 0.5 * p.keycap_width
     const keycap_yo = 0.5 * p.keycap_height
     const keycap_marks = `
     (fp_rect (start ${keycap_xo} ${keycap_yo}) (end ${-keycap_xo} ${-keycap_yo}) (layer "Dwgs.User") (stroke (width 0.15) (type solid)) (fill none))
+    `
+
+    const choc_v1_led_cutout_marks = `
+    ${''/* choc v1 led cutout marks */}
+    (fp_rect (start -2.65 6.325) (end 2.65 3.075) (layer "Dwgs.User") (width 0.15) (stroke (width 0.15) (type solid)))
+    `
+
+    const choc_v2_led_cutout_marks = `
+    ${''/* choc v2 led cutout marks */}
+    (fp_rect (start -2.75 6.405) (end 2.75 3.455) (layer "Dwgs.User") (width 0.15) (stroke (width 0.15) (type solid)))
     `
 
     const hotswap_common = `

--- a/switch_choc_v1_v2.js
+++ b/switch_choc_v1_v2.js
@@ -48,6 +48,10 @@
 //      if true, will add mx sized keycap box around the footprint (18mm)
 //    include_corner_marks: default is false
 //      if true, will add corner marks to indicate plate hole size and position
+//    include_choc_v1_led_cutout_marks: default is false
+//      if true, will add marks for the led cutout in choc v1 switch body
+//    include_choc_v2_led_cutout_marks: default is false
+//      if true, will add marks for the led cutout in choc v2 switch body
 //    include_stabilizer_pad: default is true
 //      if true, will add a corner pad for the stabilizer leg present in some
 //      Choc switches, unless choc_v2_support is false.
@@ -131,6 +135,9 @@
 //  - Add opposite stabilizer / boss holes when (choc_v2_support & solder & hotswap) options enabled together
 //  - Change v2 stabilizer / boss holes to plated
 //  - Add allow_soldermask_bridges option, which disables 'solder mask aperture bridges items with different nets' DRC check
+//
+// @mlilley's improvements:
+//  - Add options to include marks for the led cutout in choc v1 and v2 switch bodies
 
 module.exports = {
   params: {
@@ -148,6 +155,8 @@ module.exports = {
     keycap_width: 18,
     keycap_height: 18,
     include_corner_marks: false,
+    include_choc_v1_led_cutout_marks: false,
+    include_choc_v2_led_cutout_marks: false,
     include_stabilizer_pad: true,
     oval_stabilizer_pad: false,
     choc_v1_support: true,
@@ -209,6 +218,21 @@ module.exports = {
     (fp_line (start 7 -7) (end 6 -7) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
     (fp_line (start 6 7) (end 7 7) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
     (fp_line (start 7 -7) (end 7 -6) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    `
+
+    const choc_v1_led_cutout_marks = `
+    ${''/* choc v1 led cutout marks */}
+    (fp_line (start -2.65 6.325) (end 2.65 6.325) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    (fp_line (start 2.65 6.325) (end 2.65 3.075) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    (fp_line (start 2.65 3.075) (end -2.65 3.075) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    (fp_line (start -2.65 3.075) (end -2.65 6.325) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    `
+    const choc_v2_led_cutout_marks = `
+    ${''/* choc v2 led cutout marks */}
+    (fp_line (start -2.75 6.405) (end 2.75 6.405) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    (fp_line (start 2.75 6.405) (end 2.75 3.455) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    (fp_line (start 2.75 3.455) (end -2.75 3.455) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    (fp_line (start -2.75 3.455) (end -2.75 6.405) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
     `
 
     const keycap_xo = 0.5 * p.keycap_width
@@ -460,6 +484,12 @@ module.exports = {
           final += round_corner_stab_back
         }
       }
+    }
+    if (p.include_choc_v1_led_cutout_marks) {
+      final += choc_v1_led_cutout_marks
+    }
+    if (p.include_choc_v2_led_cutout_marks) {
+      final += choc_v2_led_cutout_marks
     }
     if (p.hotswap) {
       final += hotswap_common

--- a/switch_choc_v1_v2.js
+++ b/switch_choc_v1_v2.js
@@ -222,17 +222,12 @@ module.exports = {
 
     const choc_v1_led_cutout_marks = `
     ${''/* choc v1 led cutout marks */}
-    (fp_line (start -2.65 6.325) (end 2.65 6.325) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
-    (fp_line (start 2.65 6.325) (end 2.65 3.075) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
-    (fp_line (start 2.65 3.075) (end -2.65 3.075) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
-    (fp_line (start -2.65 3.075) (end -2.65 6.325) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    (fp_line (start -2.65 6.325) (end 2.65 3.075) (layer "Dwgs.User") (width 0.15) (stroke (width 0.15) (type solid)))
     `
+
     const choc_v2_led_cutout_marks = `
     ${''/* choc v2 led cutout marks */}
-    (fp_line (start -2.75 6.405) (end 2.75 6.405) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
-    (fp_line (start 2.75 6.405) (end 2.75 3.455) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
-    (fp_line (start 2.75 3.455) (end -2.75 3.455) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
-    (fp_line (start -2.75 3.455) (end -2.75 6.405) (layer "Dwgs.User") (stroke (width 0.15) (type solid)))
+    (fp_line (start -2.75 6.405) (end 2.75 3.455) (layer "Dwgs.User") (width 0.15) (stroke (width 0.15) (type solid)))
     `
 
     const keycap_xo = 0.5 * p.keycap_width


### PR DESCRIPTION
Useful for positioning components (ie: leds) within the cutout. 

Dimensions taken from Kailh specs:
v1: http://www.kailh.com/en/Products/Ks/CS/319.html
v2: http://www.kailh.com/en/Products/Ks/CS/755.html

![output](https://github.com/ceoloide/ergogen-footprints/assets/20426/4ac738d1-1230-4c7f-bf25-0c9f63e1b178)
