### PR TITLE
Add through hole to diode pad

### DIFF
--- a/diode_tht_sod123.js
+++ b/diode_tht_sod123.js
@@ -71,7 +71,7 @@ module.exports = {
             (effects (font (size 1 1) (thickness 0.15)))
         )
         `
-    const front = `
+    const front_silk = `
         (fp_line (start 0.25 0) (end 0.75 0) (layer "F.SilkS") (stroke (width 0.1) (type solid)))
         (fp_line (start 0.25 0.4) (end -0.35 0) (layer "F.SilkS") (stroke (width 0.1) (type solid)))
         (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer "F.SilkS") (stroke (width 0.1) (type solid)))
@@ -79,10 +79,13 @@ module.exports = {
         (fp_line (start -0.35 0) (end -0.35 0.55) (layer "F.SilkS") (stroke (width 0.1) (type solid)))
         (fp_line (start -0.35 0) (end -0.35 -0.55) (layer "F.SilkS") (stroke (width 0.1) (type solid)))
         (fp_line (start -0.75 0) (end -0.35 0) (layer "F.SilkS") (stroke (width 0.1) (type solid)))
+        `
+
+    const front_pads = `
         (pad "1" smd rect (at -1.65 0 ${p.r}) (size 0.9 1.2) (layers "F.Cu" "F.Paste" "F.Mask") ${p.to.str})
         (pad "2" smd rect (at 1.65 0 ${p.r}) (size 0.9 1.2) (layers "F.Cu" "F.Paste" "F.Mask") ${p.from.str})
         `
-    const back = `
+    const back_silk = `
         (fp_line (start 0.25 0) (end 0.75 0) (layer "B.SilkS") (stroke (width 0.1) (type solid)))
         (fp_line (start 0.25 0.4) (end -0.35 0) (layer "B.SilkS") (stroke (width 0.1) (type solid)))
         (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer "B.SilkS") (stroke (width 0.1) (type solid)))
@@ -90,8 +93,15 @@ module.exports = {
         (fp_line (start -0.35 0) (end -0.35 0.55) (layer "B.SilkS") (stroke (width 0.1) (type solid)))
         (fp_line (start -0.35 0) (end -0.35 -0.55) (layer "B.SilkS") (stroke (width 0.1) (type solid)))
         (fp_line (start -0.75 0) (end -0.35 0) (layer "B.SilkS") (stroke (width 0.1) (type solid)))
-        (pad "2" smd rect (at 1.65 0 ${p.r}) (size 0.9 1.2) (layers "B.Cu" "B.Paste" "B.Mask") ${p.from.str})
+        `
+    const back_pads = `
         (pad "1" smd rect (at -1.65 0 ${p.r}) (size 0.9 1.2) (layers "B.Cu" "B.Paste" "B.Mask") ${p.to.str})
+        (pad "2" smd rect (at 1.65 0 ${p.r}) (size 0.9 1.2) (layers "B.Cu" "B.Paste" "B.Mask") ${p.from.str})
+        `
+      
+    const reversible_pads = `
+        (pad "1" thru_hole rect (at -1.65 0 ${p.r}) (size 0.9 1.2) (drill 0.3) (layers "*.Cu" "*.Paste" "*.Mask") ${p.to.str})
+        (pad "2" thru_hole rect (at 1.65 0 ${p.r}) (size 0.9 1.2) (drill 0.3) (layers "*.Cu" "*.Paste" "*.Mask") ${p.from.str})
         `
 
     const tht = `
@@ -111,14 +121,17 @@ module.exports = {
 
     let final = standard_opening;
 
-    if (p.side == "F" || p.reversible) {
-      final += front;
+    if (p.side == "F" && !p.reversible) {
+      final += front_silk + front_pads;
     }
-    if (p.side == "B" || p.reversible) {
-      final += back;
+    if (p.side == "B" && !p.reversible) {
+      final += back_silk + back_pads;
     }
     if (p.include_tht) {
       final += tht;
+    }
+    if (p.reversible) {
+      final += front_silk + back_silk + reversible_pads;
     }
 
     if (p.diode_3dmodel_filename) {


### PR DESCRIPTION
Connect front and back diode pads if it is a reversible footprint without through holes