### PR TITLE
Fix nice_view reversed pins

### DIFF
--- a/display_nice_view.js
+++ b/display_nice_view.js
@@ -91,7 +91,7 @@ module.exports = {
 
     if (p.reversible) {
       socket_nets = local_nets;
-    } else if (p.side == 'B') {
+    } else if (p.side == 'F') {
       socket_nets = dst_nets.slice().reverse();
     }
 


### PR DESCRIPTION
The nice_view pins where reversed when `reversible` was `false`. Closes #32 