### PR TITLE
Add option to show silkscreen on both sides for JST PH 2 connectors

### DIFF
--- a/battery_connector_jst_ph_2.js
+++ b/battery_connector_jst_ph_2.js
@@ -32,6 +32,9 @@
 //    include_silkscreen: default is true
 //      if true it will include the silkscreen. Recommended to be true to ensure connector
 //      polarity is not reversed, which can lead to shorting and damage to the MCU
+//    include_silkscreen_on_both_sides: false
+//      if true it will include the silkscreen on both sides of the PCB. Only effective
+//      when reversible is false (jumper pads are not used).
 //    include_fabrication: default is true
 //      if true it will include the outline of the connector in the fabrication layer
 //    include_courtyard: default is true
@@ -61,6 +64,7 @@ module.exports = {
     include_traces: true,
     trace_width: 0.250,
     include_silkscreen: true,
+    include_silkscreen_on_both_sides: false,
     include_fabrication: true,
     include_courtyard: true,
     battery_connector_3dmodel_filename: '',
@@ -116,6 +120,19 @@ module.exports = {
         (fp_line (start 2.14 6.36) (end 3.06 6.36) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
         (fp_line (start 3.06 6.36) (end 3.06 5.36) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
         `
+    const front_silkscreen_mirror_on_back = `
+        (fp_line (start -1.5 7.40) (end -0.5 7.40) (stroke (width 0.1) (type solid)) (layer "B.SilkS"))
+        (fp_line (start 1.5 7.40) (end 0.5 7.40) (stroke (width 0.1) (type solid)) (layer "B.SilkS"))
+        (fp_line (start 1 6.90) (end 1 7.90) (stroke (width 0.1) (type solid)) (layer "B.SilkS"))
+        (fp_line (start -2.06 -1.46) (end -3.06 -1.46) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
+        (fp_line (start -3.06 -1.46) (end -3.06 -0.46) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
+        (fp_line (start 2.14 -1.46) (end 3.06 -1.46) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
+        (fp_line (start 3.06 -1.46) (end 3.06 -0.46) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
+        (fp_line (start -2.14 6.36) (end -3.06 6.36) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
+        (fp_line (start -3.06 6.36) (end -3.06 5.36) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
+        (fp_line (start 2.14 6.36) (end 3.06 6.36) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
+        (fp_line (start 3.06 6.36) (end 3.06 5.36) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
+        `
     const back_fabrication = `
         (fp_line (start -2.95 -1.35) (end -2.25 -1.35) (stroke (width 0.1) (type solid)) (layer "B.Fab"))
         (fp_line (start -2.95 6.25) (end -2.95 -1.35) (stroke (width 0.1) (type solid)) (layer "B.Fab"))
@@ -144,6 +161,19 @@ module.exports = {
         (fp_line (start -3.06 6.36) (end -3.06 5.36) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
         (fp_line (start 2.14 6.36) (end 3.06 6.36) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
         (fp_line (start 3.06 6.36) (end 3.06 5.36) (stroke (width 0.12) (type solid)) (layer "B.SilkS"))
+        `
+    const back_silkscreen_mirror_on_front = `
+        (fp_line (start 1.5 7.40) (end 0.5 7.40) (stroke (width 0.1) (type solid)) (layer "F.SilkS"))
+        (fp_line (start -1.5 7.40) (end -0.5 7.40) (stroke (width 0.1) (type solid)) (layer "F.SilkS"))
+        (fp_line (start -1 6.90) (end -1 7.90) (stroke (width 0.1) (type solid)) (layer "F.SilkS"))
+        (fp_line (start -2.06 -1.46) (end -3.06 -1.46) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+        (fp_line (start -3.06 -1.46) (end -3.06 -0.46) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+        (fp_line (start 2.14 -1.46) (end 3.06 -1.46) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+        (fp_line (start 3.06 -1.46) (end 3.06 -0.46) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+        (fp_line (start -2.14 6.36) (end -3.06 6.36) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+        (fp_line (start -3.06 6.36) (end -3.06 5.36) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+        (fp_line (start 2.14 6.36) (end 3.06 6.36) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+        (fp_line (start 3.06 6.36) (end 3.06 5.36) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
         `
     const front_pads = `
         (pad "1" thru_hole roundrect (at -1 0 ${p.r}) (size 1.2 1.75) (drill 0.75) (layers "*.Cu" "*.Mask") (roundrect_rratio 0.20) ${p.BAT_N.str})
@@ -328,6 +358,9 @@ module.exports = {
       if (p.include_silkscreen) {
         final += front_silkscreen;
       }
+      if (!p.reversible && p.include_silkscreen_on_both_sides) {
+        final += front_silkscreen_mirror_on_back;
+      }
     }
     if (p.side == "B" || p.reversible) {
       if (p.include_fabrication) {
@@ -338,6 +371,9 @@ module.exports = {
       }
       if (p.include_silkscreen) {
         final += back_silkscreen;
+      }
+      if (!p.reversible && p.include_silkscreen_on_both_sides) {
+        final += back_silkscreen_mirror_on_front;
       }
     }
     if (p.reversible) {


### PR DESCRIPTION
Since I don't want to use jumper pads, I'm not setting reversible to true.
But I'm still using the PCB on both sides, so showing silkscreen on both sides is useful in this case.