### PR TITLE
Typo's and a minor (improvement?) widening/loosening of the input to utility_router.js

### DIFF
--- a/rotary_encoder_ec11_ec12.js
+++ b/rotary_encoder_ec11_ec12.js
@@ -20,7 +20,7 @@ Notes:
   of the rotary encoder. The encoder mounting pads can be positioned 7.5mm instead of 5.6mm to
   avoid overlap with mounting pins.
 - The footprint can be co-located with a Choc v1 / v2 hotswap footprint, as long as the encoder
-  pads are positioned at leat 8.254 mm. If Choc v1 is co-located with the encoder, then mounting
+  pads are positioned at least 8.254 mm. If Choc v1 is co-located with the encoder, then mounting
   pads can be positioned 8.00mm instead of 5.6mm to avoid overlap with mounting pins. Choc v2
   don't have those pins, so wouldn't need the encoder mounting pads moved.
 - The footprint is inherently reversible, no solder jumper needed. Make sure to invert the pin

--- a/switch_choc_v1_v2.js
+++ b/switch_choc_v1_v2.js
@@ -47,7 +47,7 @@
 //      sets the traces and vias as locked in KiCad. Locked objects may not be manipulated
 //      or moved, and cannot be selected unless the Locked Items option is enabled in the
 //      Selection Filter panel in KiCad. Useful for a faster workflow. If using autorouting
-//      solutins like Freerouting, locking can prevent the traces and vias from being
+//      solutions like Freerouting, locking can prevent the traces and vias from being
 //      replaced.
 //    include_plated_holes: default is false
 //      Alternate version of the footprint compatible with side, reversible, hotswap, solder options in any combination.

--- a/switch_mx.js
+++ b/switch_mx.js
@@ -46,7 +46,7 @@ Params:
     sets the traces and vias as locked in KiCad. Locked objects may not be manipulated
     or moved, and cannot be selected unless the Locked Items option is enabled in the
     Selection Filter panel in KiCad. Useful for a faster workflow. If using autorouting
-    solutins like Freerouting, locking can prevent the traces and vias from being
+    solutions like Freerouting, locking can prevent the traces and vias from being
     replaced.
   solder: default is false
     if true, will include holes to solder switches (works with hotswap too)
@@ -75,7 +75,7 @@ Params:
      recommended to set below 1.7mm.
   include_keycap: default is false
     if true, will add mx sized keycap box around the footprint (18mm)
-  keycap_width: default is 18 (mm - defualt MX size)
+  keycap_width: default is 18 (mm - default MX size)
     Allows you to adjust the height of the keycap outline.
   keycap_height: default is 18 (mm - default MX size)
     Allows you to adjust the width of the keycap outline. For example,

--- a/utility_filled_zone.js
+++ b/utility_filled_zone.js
@@ -56,13 +56,13 @@
 //    hatch_gap: default is 1.5
 //      the hatch gap size (in mm)
 //    hatch_orientation: default is 0
-//      the orientation of the htach pattern (in degrees)
+//      the orientation of the hatch pattern (in degrees)
 //    hatch_smoothing_level: default is 0
 //      the level of smoothing to apply to the hatch pattern algorithm,
 //      between 0 and 3
 //    hatch_smoothing_value: default is 0.1
 //      the smoothing value used by the hatch smoothing algorithm,
-//      bertween 0.0 and 1.0
+//      between 0.0 and 1.0
 //    points: default is [[0,0],[420,0],[420,297],[0,297]]
 //      an array containing the polygon points of the filled area, in
 //      xy coordinates relative to the PCB. The default is a square area of

--- a/utility_point_debugger.js
+++ b/utility_point_debugger.js
@@ -15,7 +15,7 @@ Description:
   outline without defining points, then they won't show up.
 
 Usage:
-  ou can make enabling and disabling easy with ergogen's preprocessor:
+  You can make enabling and disabling easy with ergogen's preprocessor:
 
   ```js
   settings:


### PR DESCRIPTION
* allow a space between pairs of coordinates (shift-j adds them, this means I don't need to remove them)
* make a comma (,) between x and y of a coordinate optional (means they don't need to be added when copying from kicad)